### PR TITLE
Add .nojekyll and explain Pages setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ game.
 
 ## Play Online
 
-A simplified version of Tartis is available through GitHub Pages. Open `index.html` from the repository or visit the project page if hosted. The browser version is written in JavaScript so no installation is required.
+A simplified version of Tartis is available through GitHub Pages. Open
+`index.html` from the repository or visit the project page if hosted. The
+browser version is written in JavaScript so no installation is required.
+
+## Deploying to GitHub Pages
+
+1. Open the repository **Settings** and navigate to the **Pages** section.
+2. Select the `main` branch and the `/` root for the source.
+3. Save the settings and wait a few moments for GitHub Pages to publish your
+   site.
+
+The game will then be accessible at
+`https://<username>.github.io/<repository>/` (replace `<username>` and
+`<repository>` with your GitHub name and repository name). Once deployed, you
+can play the web version directly in your browser.
 
 Use the arrow keys to control the falling pieces just like the desktop version.


### PR DESCRIPTION
## Summary
- add `.nojekyll` so GitHub Pages serves the web files directly
- document the GitHub Pages setup steps in README

## Testing
- `python tetris.py --help` *(fails: ModuleNotFoundError: No module named 'pygame')*
- `python3 -m http.server 8080` and `curl -I http://localhost:8080`

------
https://chatgpt.com/codex/tasks/task_e_6841e1a6b4fc832a8f67dccecf016975