### PR TITLE
Add argparse so --help works without pygame

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Execute the following command from the repository directory:
 python tetris.py
 ```
 
+Run the following to see available command line options:
+
+```bash
+python tetris.py --help
+```
+
 Use the arrow keys to move and rotate the pieces. Close the window to exit the
 game.
 

--- a/tetris.py
+++ b/tetris.py
@@ -1,6 +1,15 @@
-import pygame
+import argparse
 import random
 import sys
+
+parser = argparse.ArgumentParser(
+    description='Tartis - a modern Tetris clone built with Python and Pygame.')
+parser.add_argument(
+    '--version', action='version', version='Tartis 1.0',
+    help='Show program version and exit')
+parser.parse_args()  # exits here on -h/--help before importing pygame
+
+import pygame
 
 # Game configuration
 CELL_SIZE = 30


### PR DESCRIPTION
## Summary
- add argparse setup to parse `--help` before importing pygame
- document how to see command line options

## Testing
- `python tetris.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6841e66dc598832aafbd255c285b8250