### PR TITLE
Add leaderboard and name input

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,12 @@
         #sidebar {
             margin-left: 20px;
         }
-        #score, #next {
+        #score, #next, #leaderboard {
             margin-bottom: 20px;
+        }
+        #scores {
+            padding-left: 20px;
+            margin: 0;
         }
     </style>
 </head>
@@ -43,6 +47,10 @@
             <div id="score">
                 <h3>Score</h3>
                 <div id="score-value">0</div>
+            </div>
+            <div id="leaderboard">
+                <h3>Leaderboard</h3>
+                <ol id="scores"></ol>
             </div>
         </div>
     </div>

--- a/tetris.js
+++ b/tetris.js
@@ -3,6 +3,40 @@ const context = canvas.getContext('2d');
 const preview = document.getElementById('preview');
 const previewCtx = preview.getContext('2d');
 const scoreEl = document.getElementById('score-value');
+const leaderboardEl = document.getElementById('scores');
+
+let playerName = prompt('Enter your name:') || 'Anonymous';
+
+function loadScores() {
+    try {
+        return JSON.parse(localStorage.getItem('tartisScores')) || [];
+    } catch (e) {
+        return [];
+    }
+}
+
+function saveScores(scores) {
+    localStorage.setItem('tartisScores', JSON.stringify(scores));
+}
+
+function updateLeaderboard() {
+    const scores = loadScores().sort((a, b) => b.score - a.score).slice(0, 5);
+    leaderboardEl.innerHTML = '';
+    scores.forEach(({ name, score }) => {
+        const li = document.createElement('li');
+        li.textContent = `${name}: ${score}`;
+        leaderboardEl.appendChild(li);
+    });
+}
+
+function addScore(name, value) {
+    const scores = loadScores();
+    scores.push({ name, score: value });
+    saveScores(scores);
+    updateLeaderboard();
+}
+
+updateLeaderboard();
 
 const COLS = 15;
 const ROWS = 30;
@@ -136,8 +170,12 @@ function update(time = 0) {
             current = next;
             next = new Piece(randomShape());
             if (collide(current)) {
+                addScore(playerName, score);
+                playerName = prompt('Enter your name:') || 'Anonymous';
                 board = Array.from({length: ROWS}, () => Array(COLS).fill(0));
                 score = 0;
+                current = new Piece(randomShape());
+                next = new Piece(randomShape());
             }
         }
     }


### PR DESCRIPTION
## Summary
- show leaderboard area in the sidebar
- prompt player name and store scores in localStorage
- update leaderboard after each game

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841f104965c832a8a32d56ec5836ac7