### PR TITLE
Add automatic GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy static site to Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ All logic is contained in [tetris.js](tetris.js) and the markup lives in
 
 ## Deploying to GitHub Pages
 
-1. In your repository settings, open **Pages**.
-2. Select the `main` branch and `/` root as the source.
-3. Save the settings and after a few minutes the game will be accessible at
+1. In your repository settings, open **Pages** and select the `main` branch
+   with the `/` root as the source. This only needs to be done once.
+2. The site will now automatically deploy on every push to `main` via the
+   included [deploy.yml](.github/workflows/deploy.yml) workflow.
+   After each successful run the game will be accessible at
    `https://<username>.github.io/<repository>/`.


### PR DESCRIPTION
## Summary
- automate GH Pages publishing with a workflow
- document automatic deployment in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f26a2494832aa81e541e4eafbce0