### PR TITLE
Add optional name input and persistent leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Tartis is a lightweight Tetris clone that runs entirely in the browser.
 
 Open [index.html](index.html) or visit the project's GitHub Pages site to play.
 Use **WASD** controls: `A` and `D` move pieces left and right, `S` drops them down, and `W` rotates.
+You can optionally enter a name in the sidebar to record your scores on the
+leaderboard; leaving it blank will save scores as **Anonymous**.
 
 ## Development
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         #sidebar {
             margin-left: 20px;
         }
-        #score, #next, #leaderboard {
+        #score, #next, #leaderboard, #name-entry {
             margin-bottom: 20px;
             background: rgba(255, 255, 255, 0.2);
             padding: 10px;
@@ -40,6 +40,12 @@
         #scores {
             padding-left: 20px;
             margin: 0;
+        }
+        #player-name-input {
+            width: 100%;
+            padding: 5px;
+            border: none;
+            border-radius: 5px;
         }
     </style>
 </head>
@@ -54,6 +60,9 @@
             <div id="score">
                 <h3>Score</h3>
                 <div id="score-value">0</div>
+            </div>
+            <div id="name-entry">
+                <input id="player-name-input" type="text" placeholder="Your name (optional)" />
             </div>
             <div id="leaderboard">
                 <h3>Leaderboard</h3>

--- a/tetris.js
+++ b/tetris.js
@@ -4,8 +4,11 @@ const preview = document.getElementById("preview");
 const previewCtx = preview.getContext("2d");
 const scoreEl = document.getElementById("score-value");
 const leaderboardEl = document.getElementById("scores");
+const nameInput = document.getElementById("player-name-input");
 
-let playerName = prompt("Enter your name:") || "Anonymous";
+function getPlayerName() {
+  return nameInput?.value.trim() || "Anonymous";
+}
 
 function loadScores() {
   try {
@@ -192,8 +195,7 @@ function update(time = 0) {
       current = next;
       next = new Piece(randomShape());
       if (collide(current)) {
-        addScore(playerName, score);
-        playerName = prompt("Enter your name:") || "Anonymous";
+        addScore(getPlayerName(), score);
         board = Array.from({ length: ROWS }, () => Array(COLS).fill(0));
         score = 0;
         current = new Piece(randomShape());


### PR DESCRIPTION
## Summary
- allow score submission without entering a name
- add a name input field in the sidebar
- document optional naming in README

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6841f3ce58bc832a8a1cdd6eb5b61aee