### PR TITLE
Fix rotation for non-square Tetris pieces

### DIFF
--- a/tetris.js
+++ b/tetris.js
@@ -135,9 +135,8 @@ function merge(piece) {
 }
 
 function rotate(piece) {
-  const m = piece.shape.map((row, y) =>
-    row.map((_, x) => piece.shape[piece.shape.length - x - 1][y]),
-  );
+  const { shape } = piece;
+  const m = shape[0].map((_, x) => shape.map((row) => row[x]).reverse());
   const clone = { shape: m, x: piece.x, y: piece.y };
   if (!collide(clone)) piece.shape = m;
 }


### PR DESCRIPTION
## Summary
- handle rectangular piece rotation correctly

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6841f5111720832a8ada5dac3b8d61a2