### PR TITLE
Improve high score handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Tartis is a lightweight Tetris clone that runs entirely in the browser.
 Open [index.html](index.html) or visit the project's GitHub Pages site to play.
 Use **WASD** controls: `A` and `D` move pieces left and right, `S` drops them down, and `W` rotates.
 You can optionally enter a name in the sidebar to record your scores on the
-leaderboard; leaving it blank will save scores as **Anonymous**.
+leaderboard; leaving it blank will save scores as **Anonymous**. Only the five
+highest scores are stored locally.
 
 ## Development
 

--- a/tetris.js
+++ b/tetris.js
@@ -37,7 +37,9 @@ function updateLeaderboard() {
 function addScore(name, value) {
   const scores = loadScores();
   scores.push({ name, score: value });
-  saveScores(scores);
+  // Sort scores from highest to lowest and keep only the best five
+  const top = scores.sort((a, b) => b.score - a.score).slice(0, 5);
+  saveScores(top);
   updateLeaderboard();
 }
 


### PR DESCRIPTION
## Summary
- keep only the best five scores when saving
- document that only top five scores are stored

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842001eaca0832ab2d8928558d6f2af