### PR TITLE
Add clear scores option

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,16 @@
             border-radius: 5px;
             box-sizing: border-box;
         }
+        #clear-scores {
+            width: 100%;
+            margin-top: 10px;
+            padding: 6px 10px;
+            background: var(--panel-bg);
+            border: 1px solid #fff;
+            border-radius: 5px;
+            cursor: pointer;
+            color: var(--text-color);
+        }
         #score-value {
             font-size: 2em;
             margin-top: 5px;
@@ -105,6 +115,7 @@
             <div id="leaderboard">
                 <h3>Leaderboard</h3>
                 <ol id="scores"></ol>
+                <button id="clear-scores">Clear Scores</button>
             </div>
         </div>
     </div>

--- a/tetris.js
+++ b/tetris.js
@@ -5,6 +5,7 @@ const previewCtx = preview.getContext("2d");
 const scoreEl = document.getElementById("score-value");
 const leaderboardEl = document.getElementById("scores");
 const nameInput = document.getElementById("player-name-input");
+const clearScoresBtn = document.getElementById("clear-scores");
 
 function getPlayerName() {
   return nameInput?.value.trim() || "Anonymous";
@@ -20,6 +21,11 @@ function loadScores() {
 
 function saveScores(scores) {
   localStorage.setItem("tartisScores", JSON.stringify(scores));
+}
+
+function clearScores() {
+  localStorage.removeItem("tartisScores");
+  updateLeaderboard();
 }
 
 function updateLeaderboard() {
@@ -42,6 +48,10 @@ function addScore(name, value) {
 }
 
 updateLeaderboard();
+
+if (clearScoresBtn) {
+  clearScoresBtn.addEventListener("click", clearScores);
+}
 
 const COLS = 20;
 const ROWS = 30;


### PR DESCRIPTION
## Summary
- add a button below the leaderboard
- style the new button
- implement `clearScores()` in `tetris.js`
- hook the button to the clearing logic

## Testing
- `bash install_dependencies.sh` *(fails: No project found)*

------
https://chatgpt.com/codex/tasks/task_e_684200210354832abd29143a7042f3fd