### PR TITLE
Add level display to Tartis

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         #sidebar {
             margin-left: 20px;
         }
-        #score, #next, #leaderboard, #name-entry {
+        #score, #level, #next, #leaderboard, #name-entry {
             margin-bottom: 20px;
             background: var(--panel-bg);
             padding: 10px;
@@ -101,7 +101,7 @@
             cursor: pointer;
             color: var(--text-color);
         }
-        #score-value {
+        #score-value, #level-value {
             font-size: 2em;
             margin-top: 5px;
         }
@@ -161,6 +161,10 @@
                 <div id="score">
                 <h3>Score</h3>
                 <div id="score-value">0</div>
+            </div>
+            <div id="level">
+                <h3>Level</h3>
+                <div id="level-value">1</div>
             </div>
             <div id="name-entry">
                 <input id="player-name-input" type="text" placeholder="Your name (optional)" />

--- a/tetris.js
+++ b/tetris.js
@@ -3,6 +3,7 @@ const context = canvas.getContext("2d");
 const preview = document.getElementById("preview");
 const previewCtx = preview.getContext("2d");
 const scoreEl = document.getElementById("score-value");
+const levelEl = document.getElementById("level-value");
 const leaderboardEl = document.getElementById("scores");
 const nameInput = document.getElementById("player-name-input");
 const clearScoresBtn = document.getElementById("clear-scores");
@@ -304,6 +305,10 @@ function draw() {
   drawMatrix(next.shape, offsetX, offsetY, previewCtx);
 
   scoreEl.textContent = score;
+  if (levelEl) {
+    const level = Math.floor(linesCleared / 10) + 1;
+    levelEl.textContent = level;
+  }
 }
 
 function update(time = 0) {


### PR DESCRIPTION
## Summary
- show player's level in the sidebar
- update styling so level panel matches existing sidebar panels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842472a1d48832aa07487ae12fbe994