### PR TITLE
Zoom out page elements by 25%

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,8 +110,10 @@
             flex-direction: column;
             align-items: center;
             gap: 0.5rem;
-            padding: 2rem;
-            max-width: 95vw;
+            padding: 5vmin;
+            width: 75vw;
+            max-width: 600px;
+            box-sizing: border-box;
         }
 
         .game-title {
@@ -123,8 +125,8 @@
         }
 
         .board-wrapper {
-            width: 80vw;
-            max-width: 600px;
+            width: 60vw;
+            max-width: 450px;
             aspect-ratio: 2 / 3;
             position: relative;
         }


### PR DESCRIPTION
## Summary
- reduce `.game-container` width to 75vw
- add responsive padding to the container
- keep board wrapper at 60vw/450px

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684248972ebc832a9768d8219ec41280