### PR TITLE
Add difficulty meter to sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
             max-width: 150px;
             box-sizing: border-box;
         }
-        #next, #leaderboard, #name-entry {
+        #next, #leaderboard, #name-entry, #difficulty-meter {
             margin-bottom: 20px;
             background: var(--panel-bg);
             padding: 10px;
@@ -103,6 +103,20 @@
             border-radius: 5px;
             cursor: pointer;
             color: var(--text-color);
+        }
+        #difficulty-bar-container {
+            width: 100%;
+            height: 10px;
+            background: #555;
+            border-radius: 5px;
+            margin-top: 5px;
+            overflow: hidden;
+        }
+        #difficulty-bar {
+            height: 100%;
+            width: 0%;
+            background: #4caf50;
+            transition: width 0.2s;
         }
         .game-container {
             display: flex;
@@ -170,6 +184,12 @@
                 <div id="controls">
                     <button id="start-btn">Start</button>
                     <button id="pause-btn" disabled>Pause</button>
+                </div>
+                <div id="difficulty-meter">
+                    <h3>Difficulty</h3>
+                    <div id="difficulty-bar-container">
+                        <div id="difficulty-bar"></div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/tetris.js
+++ b/tetris.js
@@ -8,6 +8,7 @@ const nameInput = document.getElementById("player-name-input");
 const clearScoresBtn = document.getElementById("clear-scores");
 const startBtn = document.getElementById("start-btn");
 const pauseBtn = document.getElementById("pause-btn");
+const difficultyBar = document.getElementById("difficulty-bar");
 
 let animationId = null;
 let isPaused = false;
@@ -152,6 +153,7 @@ function resetGame() {
   lastTime = 0;
   score = 0;
   draw();
+  updateDifficultyMeter();
 }
 
 function startGame() {
@@ -188,6 +190,16 @@ function updateDropInterval() {
     MIN_DROP_INTERVAL,
     BASE_DROP_INTERVAL - level * LEVEL_SPEED_STEP - scoreFactor
   );
+  updateDifficultyMeter();
+}
+
+function updateDifficultyMeter() {
+  if (!difficultyBar) return;
+  const percent =
+    ((BASE_DROP_INTERVAL - dropInterval) /
+      (BASE_DROP_INTERVAL - MIN_DROP_INTERVAL)) *
+    100;
+  difficultyBar.style.width = `${Math.min(100, Math.max(0, percent))}%`;
 }
 
 function randomShape() {
@@ -385,3 +397,4 @@ pauseBtn.addEventListener('click', () => {
 pauseBtn.disabled = true;
 
 resizeCanvas();
+updateDifficultyMeter();


### PR DESCRIPTION
## Summary
- show a difficulty meter below the start/pause controls
- update drop interval logic to update the meter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842586a7584832a83e398109dfddf96