### PR TITLE
Move difficulty meter above next block preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,12 @@
                 <canvas id="gameCanvas"></canvas>
             </div>
             <div id="sidebar">
+                <div id="difficulty-meter">
+                    <h3>Difficulty</h3>
+                    <div id="difficulty-bar-container">
+                        <div id="difficulty-bar"></div>
+                    </div>
+                </div>
                 <div id="next">
                     <h3>Next</h3>
                     <canvas id="preview" width="90" height="90"></canvas>
@@ -196,12 +202,6 @@
                 <div id="hold">
                     <h3>Hold</h3>
                     <canvas id="hold-preview" width="90" height="90"></canvas>
-                </div>
-                <div id="difficulty-meter">
-                    <h3>Difficulty</h3>
-                    <div id="difficulty-bar-container">
-                        <div id="difficulty-bar"></div>
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- reorganize sidebar order so difficulty meter appears above the next block preview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68430c73af54832ab6c690697f941a15