### PR TITLE
Swap leaderboard and name input

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,13 +172,13 @@
         <h1 class="game-title">Tartis</h1>
         <div id="game">
             <div id="left-sidebar">
-                <div id="name-entry">
-                    <input id="player-name-input" type="text" placeholder="Your name (optional)" />
-                </div>
                 <div id="leaderboard">
                     <h3>Leaderboard</h3>
                     <ol id="scores"></ol>
                     <button id="clear-scores">Clear Scores</button>
+                </div>
+                <div id="name-entry">
+                    <input id="player-name-input" type="text" placeholder="Your name (optional)" />
                 </div>
                 <div id="controls">
                     <button id="start-btn">Start</button>


### PR DESCRIPTION
## Summary
- reorder left sidebar so leaderboard shows above the name entry field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684313103b38832ab86b813c55ecd204